### PR TITLE
fix: harden workflow guard execution

### DIFF
--- a/entomokit/cli_schema.py
+++ b/entomokit/cli_schema.py
@@ -65,6 +65,7 @@ def _action_schema(action: argparse.Action) -> dict[str, object]:
         "name": name,
         "dest": action.dest,
         "options": list(action.option_strings),
+        "action_kind": _infer_action_kind(action),
         "required": bool(getattr(action, "required", False)),
         "default": _stringify_default(getattr(action, "default", None)),
         "choices": [str(choice) for choice in action.choices]
@@ -82,6 +83,14 @@ def _infer_value_type(action: argparse.Action) -> str:
     if action.type in (int, float, str):
         return action.type.__name__
     return "str"
+
+
+def _infer_action_kind(action: argparse.Action) -> str:
+    if isinstance(action, argparse._StoreTrueAction):
+        return "store_true"
+    if isinstance(action, argparse._StoreFalseAction):
+        return "store_false"
+    return "store"
 
 
 def build_command_schemas(

--- a/entomokit/execution_policy.py
+++ b/entomokit/execution_policy.py
@@ -2,13 +2,49 @@
 
 from __future__ import annotations
 
+import os
 import shlex
+from pathlib import Path
 
 
-ALLOWED_PREFIXES = (
-    "entomokit",
-    "python skills/entomokit-workflow/scripts/export_cli_schema.py",
-)
+ALLOWED_SCHEMA_EXPORT_SCRIPT = "skills/entomokit-workflow/scripts/export_cli_schema.py"
+FORBIDDEN_SHELL_TOKENS = ("&&", "||", "|", ";", "&", ">", "<", "`", "\n", "\r")
+
+
+def _contains_forbidden_shell_syntax(command: str) -> str | None:
+    for token in FORBIDDEN_SHELL_TOKENS:
+        if token in command:
+            return token
+    return None
+
+
+def _strip_wrapping_quotes(token: str) -> str:
+    if len(token) >= 2 and token[0] == token[-1] and token[0] in {'"', "'"}:
+        return token[1:-1]
+    return token
+
+
+def _split_command(command: str) -> list[str]:
+    parts = shlex.split(command, posix=os.name != "nt")
+    if os.name == "nt":
+        return [_strip_wrapping_quotes(part) for part in parts]
+    return parts
+
+
+def _binary_stem(token: str) -> str:
+    return Path(token).stem.lower()
+
+
+def _is_python_binary(token: str) -> bool:
+    stem = _binary_stem(token)
+    return stem == "python" or stem.startswith("python")
+
+
+def _normalize_script_path(token: str) -> str:
+    normalized = token.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
 
 
 def validate_execution_command(
@@ -21,17 +57,43 @@ def validate_execution_command(
     if not trimmed:
         return {"allowed": False, "reason": "Command is empty."}
 
-    if any(trimmed.startswith(prefix) for prefix in ALLOWED_PREFIXES):
-        return {"allowed": True, "reason": "allowed"}
+    forbidden = _contains_forbidden_shell_syntax(trimmed)
+    if forbidden is not None:
+        return {
+            "allowed": False,
+            "reason": (
+                "Shell control syntax is not allowed in guarded commands. "
+                f"Found forbidden token: {forbidden!r}"
+            ),
+        }
 
     try:
-        parts = shlex.split(trimmed)
+        parts = _split_command(trimmed)
     except ValueError:
         return {"allowed": False, "reason": "Command parsing failed."}
 
-    binary = parts[0] if parts else ""
-    if binary == "entomokit":
-        return {"allowed": True, "reason": "allowed"}
+    if not parts:
+        return {"allowed": False, "reason": "Command is empty."}
+
+    if _binary_stem(parts[0]) == "entomokit":
+        return {
+            "allowed": True,
+            "reason": "allowed",
+            "argv": parts,
+            "command_kind": "entomokit",
+        }
+
+    if (
+        len(parts) >= 2
+        and _is_python_binary(parts[0])
+        and _normalize_script_path(parts[1]) == ALLOWED_SCHEMA_EXPORT_SCRIPT
+    ):
+        return {
+            "allowed": True,
+            "reason": "allowed",
+            "argv": parts,
+            "command_kind": "schema_export",
+        }
 
     if allow_fallback_script:
         reason = (fallback_reason or "").strip()
@@ -43,6 +105,8 @@ def validate_execution_command(
         return {
             "allowed": True,
             "reason": f"fallback-approved: {reason}",
+            "argv": parts,
+            "command_kind": "fallback",
         }
 
     return {

--- a/entomokit/workflow_gate.py
+++ b/entomokit/workflow_gate.py
@@ -2,26 +2,89 @@
 
 from __future__ import annotations
 
+import os
+import shlex
 import subprocess
+import sys
 from collections.abc import Callable, Mapping
+from pathlib import Path
 from typing import Any, cast
 
+from entomokit.cli_schema import get_command_schema
 from entomokit.execution_policy import validate_execution_command
 from entomokit.param_guard import render_parameter_card, validate_parameters
 
 
-Runner = Callable[[str], tuple[int, str, str]]
+Runner = Callable[[list[str]], tuple[int, str, str]]
 
 
-def _default_runner(command: str) -> tuple[int, str, str]:
+def _format_command(argv: list[str]) -> str:
+    if os.name == "nt":
+        return subprocess.list2cmdline(argv)
+    return shlex.join(argv)
+
+
+def _resolve_process_argv(argv: list[str]) -> list[str]:
+    if argv and Path(argv[0]).stem.lower() == "entomokit":
+        return [sys.executable, "-m", "entomokit.main", *argv[1:]]
+    return argv
+
+
+def _default_runner(argv: list[str]) -> tuple[int, str, str]:
     completed = subprocess.run(
-        command,
-        shell=True,
+        _resolve_process_argv(argv),
+        shell=False,
         capture_output=True,
         text=True,
         check=False,
     )
     return completed.returncode, completed.stdout, completed.stderr
+
+
+def _extract_entomokit_command_path(argv: list[str]) -> str:
+    words: list[str] = []
+    for token in argv[1:]:
+        if token.startswith("-"):
+            break
+        words.append(token)
+    return " ".join(words)
+
+
+def _build_entomokit_argv(
+    command_path: str,
+    approved_params: Mapping[str, object],
+) -> list[str]:
+    schema = get_command_schema(command_path)
+    if schema is None:
+        raise ValueError(f"Unknown command schema: {command_path}")
+
+    argv = ["entomokit", *command_path.split()]
+    for raw_param in cast(list[object], schema.get("parameters", [])):
+        param = cast(dict[str, object], raw_param)
+        name = str(param["name"])
+        options = [str(opt) for opt in cast(list[object], param.get("options") or [])]
+        action_kind = str(param.get("action_kind", "store"))
+        value = approved_params.get(name)
+
+        if action_kind == "store_true":
+            if bool(value):
+                argv.append(name)
+            continue
+
+        if action_kind == "store_false":
+            if value is False:
+                argv.append(name)
+            continue
+
+        if value is None:
+            continue
+
+        if options:
+            argv.extend([name, str(value)])
+        else:
+            argv.append(str(value))
+
+    return argv
 
 
 def run_guarded_step(
@@ -65,9 +128,38 @@ def run_guarded_step(
         }
 
     approved_params = cast(dict[str, Any], validation.get("final_values", {}))
+    policy_argv = [str(part) for part in cast(list[object], policy.get("argv", []))]
+    command_kind = str(policy.get("command_kind", ""))
+
+    execution_argv = policy_argv
+    if command_kind == "entomokit":
+        expected_path = " ".join(command_path.split())
+        actual_path = _extract_entomokit_command_path(policy_argv)
+        if actual_path != expected_path:
+            message = (
+                "Requested entomokit command path does not match the guarded step. "
+                f"Expected {expected_path!r}, got {actual_path or '<root>'!r}."
+            )
+            return {
+                "status": "blocked",
+                "message": message,
+                "parameter_card": card,
+                "errors": [message],
+            }
+
+        try:
+            execution_argv = _build_entomokit_argv(expected_path, approved_params)
+        except ValueError as exc:
+            message = str(exc)
+            return {
+                "status": "blocked",
+                "message": message,
+                "parameter_card": card,
+                "errors": [message],
+            }
 
     active_runner = runner or _default_runner
-    code, stdout, stderr = active_runner(command)
+    code, stdout, stderr = active_runner(execution_argv)
 
     final_status = "success" if code == 0 else "failed"
 
@@ -75,6 +167,7 @@ def run_guarded_step(
         "status": final_status,
         "step_name": step_name,
         "approved_params": approved_params,
+        "executed_command": _format_command(execution_argv),
         "outputs": outputs or [],
         "return_code": code,
         "stdout": stdout,

--- a/skills/entomokit-workflow/scripts/export_cli_schema.py
+++ b/skills/entomokit-workflow/scripts/export_cli_schema.py
@@ -6,6 +6,17 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from pathlib import Path
+
+
+def _ensure_project_root_on_path() -> None:
+    root = Path(__file__).resolve().parents[3]
+    root_str = str(root)
+    if root_str not in sys.path:
+        sys.path.insert(0, root_str)
+
+
+_ensure_project_root_on_path()
 
 from entomokit.cli_schema import build_command_schemas
 

--- a/skills/entomokit-workflow/scripts/run_guarded_step.py
+++ b/skills/entomokit-workflow/scripts/run_guarded_step.py
@@ -5,6 +5,18 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
+from pathlib import Path
+
+
+def _ensure_project_root_on_path() -> None:
+    root = Path(__file__).resolve().parents[3]
+    root_str = str(root)
+    if root_str not in sys.path:
+        sys.path.insert(0, root_str)
+
+
+_ensure_project_root_on_path()
 
 from entomokit.workflow_gate import run_guarded_step
 
@@ -17,7 +29,11 @@ def _parser() -> argparse.ArgumentParser:
         required=True,
         help="Schema command path, e.g. clean or classify train",
     )
-    p.add_argument("--command", required=True, help="Shell command to execute")
+    p.add_argument(
+        "--command",
+        required=True,
+        help="Single command to validate and execute through the guarded runner.",
+    )
     p.add_argument(
         "--param",
         action="append",

--- a/src/common/annotation_writer.py
+++ b/src/common/annotation_writer.py
@@ -36,9 +36,6 @@ def write_annotations(
         fmt: One of 'coco', 'yolo', 'voc'.
         coco_bbox_format: 'xywh' or 'xyxy' (COCO only).
     """
-    import cv2
-    import supervision as sv
-
     fmt = fmt.lower()
     if fmt not in SUPPORTED_FORMATS:
         raise ValueError(
@@ -48,6 +45,9 @@ def write_annotations(
         raise ValueError(
             f"Unknown coco_bbox_format: {coco_bbox_format!r}. Use 'xywh' or 'xyxy'."
         )
+
+    import cv2
+    import supervision as sv
 
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -130,7 +130,8 @@ def _write_yolo_yaml(
     deduped = list(dict.fromkeys(class_names))  # preserve order, remove dups
     quoted = ", ".join(f'"{c}"' for c in deduped)
     yaml_path.write_text(
-        f"train: {train_path}\nnc: {len(deduped)}\nnames: [{quoted}]\n"
+        f"train: {train_path}\nnc: {len(deduped)}\nnames: [{quoted}]\n",
+        encoding="utf-8",
     )
 
 
@@ -138,13 +139,17 @@ def _write_voc_imagesets(out_dir: Path, stems: List[str]) -> None:
     """Write ImageSets/Main/default.txt."""
     imagesets_dir = out_dir / "ImageSets" / "Main"
     imagesets_dir.mkdir(parents=True, exist_ok=True)
-    (imagesets_dir / "default.txt").write_text("\n".join(stems) + "\n")
+    (imagesets_dir / "default.txt").write_text(
+        "\n".join(stems) + "\n", encoding="utf-8"
+    )
 
 
 def _rewrite_coco_bbox_to_xyxy(json_path: Path) -> None:
     """In-place convert bbox in COCO JSON from xywh → xyxy."""
-    data = json.loads(json_path.read_text())
+    data = json.loads(json_path.read_text(encoding="utf-8"))
     for ann in data.get("annotations", []):
         x, y, w, h = ann["bbox"]
         ann["bbox"] = [x, y, x + w, y + h]
-    json_path.write_text(json.dumps(data, indent=2, ensure_ascii=False))
+    json_path.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8"
+    )

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -285,8 +285,8 @@ class COCOMetadataManager:
         try:
             output_path.parent.mkdir(parents=True, exist_ok=True)
             
-            with open(output_path, 'w') as f:
-                json.dump(self.to_dict(), f, indent=2)
+            with open(output_path, "w", encoding="utf-8") as f:
+                json.dump(self.to_dict(), f, indent=2, ensure_ascii=False)
         except OSError as e:
             raise IOError(f"Failed to save COCO metadata to {output_path}: {e}")
     

--- a/src/synthesis/processor.py
+++ b/src/synthesis/processor.py
@@ -882,7 +882,7 @@ class SynthesisProcessor:
         base_name = Path(output_filename).stem
         annotations_path = annotations_dir / f"{base_name}.xml"
 
-        with open(annotations_path, "w") as f:
+        with open(annotations_path, "w", encoding="utf-8") as f:
             f.write(xml_content)
 
     def _save_yolo_single(
@@ -964,12 +964,14 @@ class SynthesisProcessor:
         base_name = Path(output_filename).stem
         labels_path = labels_dir / f"{base_name}.txt"
 
-        with open(labels_path, "w") as f:
+        with open(labels_path, "w", encoding="utf-8") as f:
             f.write(yolo_content)
 
         yaml_dir = output_dir if output_dir else Path(self.output_subdir).parent
         yaml_path = yaml_dir / "data.yaml"
-        yaml_path.write_text('train: images\nnc: 1\nnames: ["insect"]\n')
+        yaml_path.write_text(
+            'train: images\nnc: 1\nnames: ["insect"]\n', encoding="utf-8"
+        )
 
     def _get_annotation_output_dir(self, output_dir: Path) -> Path:
         """Get annotation output directory based on format (detcli-aligned paths)."""

--- a/tests/test_annotation_writer.py
+++ b/tests/test_annotation_writer.py
@@ -5,9 +5,13 @@ import pytest
 from pathlib import Path
 
 
-def _make_dataset_and_write(tmp_path, fmt, coco_bbox_format="xywh"):
+def _make_dataset_and_write(
+    tmp_path, fmt, coco_bbox_format="xywh", class_names=None
+):
     """Helper: create minimal writer call with real supervision."""
-    import supervision as sv
+    pytest.importorskip("cv2")
+    sv = pytest.importorskip("supervision")
+    pytest.importorskip("PIL")
     import numpy as np
     from src.common.annotation_writer import write_annotations
     from PIL import Image
@@ -24,7 +28,7 @@ def _make_dataset_and_write(tmp_path, fmt, coco_bbox_format="xywh"):
     write_annotations(
         image_paths=[img_path],
         detections_per_image={str(img_path): dets},
-        class_names=["insect"],
+        class_names=class_names or ["insect"],
         out_dir=tmp_path / "out",
         fmt=fmt,
         coco_bbox_format=coco_bbox_format,
@@ -72,6 +76,35 @@ def test_yolo_yaml_quoted_names(tmp_path):
     assert "train: images" in content
     assert 'names: ["insect"]' in content
     assert "nc: 1" in content
+
+
+def test_yolo_yaml_written_as_utf8(tmp_path):
+    from src.common.annotation_writer import _write_yolo_yaml
+
+    yaml_path = tmp_path / "data.yaml"
+    _write_yolo_yaml(yaml_path, ["昆虫"])
+    raw = yaml_path.read_bytes()
+    assert "昆虫".encode("utf-8") in raw
+
+
+def test_coco_bbox_rewrite_writes_utf8(tmp_path):
+    from src.common.annotation_writer import _rewrite_coco_bbox_to_xyxy
+
+    json_path = tmp_path / "annotations.coco.json"
+    json_path.write_text(
+        json.dumps(
+            {
+                "categories": [{"id": 1, "name": "昆虫"}],
+                "annotations": [{"bbox": [10, 10, 40, 40]}],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    _rewrite_coco_bbox_to_xyxy(json_path)
+    raw = json_path.read_bytes()
+    assert "昆虫".encode("utf-8") in raw
 
 
 def test_voc_layout(tmp_path):

--- a/tests/test_cli_schema.py
+++ b/tests/test_cli_schema.py
@@ -21,6 +21,7 @@ def test_clean_schema_contains_required_and_enum_metadata() -> None:
     assert params["--input-dir"]["required"] is True
     assert params["--out-dir"]["required"] is True
     assert params["--out-image-format"]["value_hint"] == "jpg | png | tif"
+    assert params["--keep-exif"]["action_kind"] == "store_true"
 
 
 def test_unknown_command_schema_returns_none() -> None:

--- a/tests/test_execution_policy.py
+++ b/tests/test_execution_policy.py
@@ -10,6 +10,7 @@ def test_validate_execution_command_allows_entomokit() -> None:
         "entomokit clean --input-dir ./raw --out-dir ./out"
     )
     assert result["allowed"] is True
+    assert result["command_kind"] == "entomokit"
 
 
 def test_validate_execution_command_blocks_custom_python_script() -> None:
@@ -24,6 +25,25 @@ def test_validate_execution_command_allows_schema_export_script() -> None:
     )
     result = validate_execution_command(cmd)
     assert result["allowed"] is True
+    assert result["command_kind"] == "schema_export"
+
+
+def test_validate_execution_command_blocks_prefix_spoofing() -> None:
+    result = validate_execution_command("entomokitx clean --input-dir ./raw")
+    assert result["allowed"] is False
+
+    result = validate_execution_command(
+        "python skills/entomokit-workflow/scripts/export_cli_schema.py.evil"
+    )
+    assert result["allowed"] is False
+
+
+def test_validate_execution_command_blocks_shell_control_syntax() -> None:
+    result = validate_execution_command(
+        "entomokit clean --input-dir ./raw --out-dir ./out && echo PWNED"
+    )
+    assert result["allowed"] is False
+    assert "Shell control syntax is not allowed" in str(result["reason"])
 
 
 def test_validate_execution_command_allows_fallback_with_reason() -> None:
@@ -34,3 +54,4 @@ def test_validate_execution_command_allows_fallback_with_reason() -> None:
     )
     assert result["allowed"] is True
     assert str(result["reason"]).startswith("fallback-approved:")
+    assert result["command_kind"] == "fallback"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -6,6 +6,9 @@ import tempfile
 import numpy as np
 import pytest
 from pathlib import Path
+
+pytest.importorskip("cv2")
+
 from src.metadata import COCOMetadataManager, mask_to_bbox, mask_to_polygon
 
 
@@ -222,7 +225,7 @@ def test_coco_metadata_manager_save():
         # Verify file exists and content is valid JSON
         assert output_path.exists()
         
-        with open(output_path) as f:
+        with open(output_path, encoding="utf-8") as f:
             data = json.load(f)
         
         assert "images" in data
@@ -239,6 +242,20 @@ def test_coco_metadata_manager_save_creates_dirs():
         manager.save(output_path)
         
         assert output_path.exists()
+
+
+def test_coco_metadata_manager_save_writes_utf8() -> None:
+    manager = COCOMetadataManager()
+    manager.add_category("昆虫")
+    manager.add_image("中文.png", 100, 100)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = Path(tmpdir) / "annotations.json"
+        manager.save(output_path)
+
+        raw = output_path.read_bytes()
+        assert "昆虫".encode("utf-8") in raw
+        assert "中文.png".encode("utf-8") in raw
 
 
 def test_coco_metadata_manager_multiple_categories():

--- a/tests/test_run_guarded_step_script.py
+++ b/tests/test_run_guarded_step_script.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+from pathlib import Path
 
 
 SCRIPT = "skills/entomokit-workflow/scripts/run_guarded_step.py"
@@ -35,17 +36,26 @@ def test_run_guarded_step_script_blocks_custom_script_command() -> None:
     assert completed.returncode == 2
 
 
-def test_run_guarded_step_script_executes_entomokit_command() -> None:
+def test_run_guarded_step_script_executes_entomokit_command(tmp_path) -> None:
+    csv_path = tmp_path / "images.csv"
+    out_dir = tmp_path / "out"
+    csv_path.write_text("image,label\nimg1.jpg,a\nimg2.jpg,a\n", encoding="utf-8")
+
     completed = subprocess.run(
         [
             sys.executable,
             SCRIPT,
             "--step-name",
-            "doctor",
+            "split-csv",
             "--command-path",
-            "doctor",
+            "split-csv",
             "--command",
-            "entomokit --version",
+            (
+                f"entomokit split-csv --raw-image-csv {csv_path} "
+                f"--out-dir {out_dir}"
+            ),
+            f"--param=--raw-image-csv={csv_path}",
+            f"--param=--out-dir={out_dir}",
         ],
         capture_output=True,
         text=True,
@@ -56,6 +66,32 @@ def test_run_guarded_step_script_executes_entomokit_command() -> None:
     assert payload["status"] == "success"
     assert payload["return_code"] == 0
     assert completed.returncode == 0
+    assert (out_dir / "train.csv").exists()
+
+
+def test_run_guarded_step_script_blocks_shell_control_syntax() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            SCRIPT,
+            "--step-name",
+            "clean",
+            "--command-path",
+            "clean",
+            "--command",
+            "entomokit clean --input-dir ./raw --out-dir ./out && echo PWNED",
+            "--param=--input-dir=./raw",
+            "--param=--out-dir=./out",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    payload = json.loads(completed.stdout)
+    assert payload["status"] == "blocked"
+    assert "Shell control syntax is not allowed" in payload["message"]
+    assert completed.returncode == 2
 
 
 def test_run_guarded_step_script_allows_fallback_when_explicit() -> None:

--- a/tests/test_synthesis_annotation_formats.py
+++ b/tests/test_synthesis_annotation_formats.py
@@ -1,4 +1,7 @@
 import numpy as np
+import pytest
+
+pytest.importorskip("cv2")
 
 from src.synthesis.processor import SynthesisProcessor
 
@@ -46,7 +49,7 @@ def test_save_yolo_single_does_not_pass_unsupported_mask_area(tmp_path):
     assert (tmp_path / "labels" / "sample.txt").exists()
     yaml_path = tmp_path / "data.yaml"
     assert yaml_path.exists()
-    yaml_content = yaml_path.read_text()
+    yaml_content = yaml_path.read_text(encoding="utf-8")
     assert "nc: 1" in yaml_content
     assert 'names: ["insect"]' in yaml_content
     assert "train: images" in yaml_content

--- a/tests/test_workflow_gate.py
+++ b/tests/test_workflow_gate.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from entomokit.workflow_gate import run_guarded_step
 
 
-def _ok_runner(command: str) -> tuple[int, str, str]:
-    return 0, f"ran: {command}", ""
+def _ok_runner(command: list[str]) -> tuple[int, str, str]:
+    return 0, f"ran: {' '.join(command)}", ""
 
 
 def test_run_guarded_step_success() -> None:
@@ -22,6 +22,7 @@ def test_run_guarded_step_success() -> None:
     assert result["status"] == "success"
     assert result["step_name"] == "clean"
     assert str(result["approved_params"].get("--input-dir")) == "./raw"
+    assert result["executed_command"].startswith("entomokit clean")
 
 
 def test_run_guarded_step_blocks_non_entomokit_command() -> None:
@@ -66,3 +67,67 @@ def test_run_guarded_step_blocks_invalid_params_before_execution() -> None:
 
     assert result["status"] == "blocked"
     assert "must be one of" in "\n".join(result["errors"])
+
+
+def test_run_guarded_step_rebuilds_entomokit_command_from_approved_params() -> None:
+    executed: list[list[str]] = []
+
+    def runner(command: list[str]) -> tuple[int, str, str]:
+        executed.append(command)
+        return 0, "", ""
+
+    result = run_guarded_step(
+        step_name="clean",
+        command_path="clean",
+        command="entomokit clean --input-dir ./raw --out-dir ./MALICIOUS --threads xyz",
+        user_inputs={"--input-dir": "./raw", "--out-dir": "./safe"},
+        runner=runner,
+    )
+
+    assert result["status"] == "success"
+    assert executed == [
+        [
+            "entomokit",
+            "clean",
+            "--input-dir",
+            "./raw",
+            "--out-dir",
+            "./safe",
+            "--out-short-size",
+            "512",
+            "--out-image-format",
+            "jpg",
+            "--threads",
+            "12",
+            "--dedup-mode",
+            "md5",
+            "--phash-threshold",
+            "5",
+        ]
+    ]
+
+
+def test_run_guarded_step_blocks_shell_control_syntax() -> None:
+    result = run_guarded_step(
+        step_name="clean",
+        command_path="clean",
+        command="entomokit clean --input-dir ./raw --out-dir ./out && echo PWNED",
+        user_inputs={"--input-dir": "./raw", "--out-dir": "./out"},
+        runner=_ok_runner,
+    )
+
+    assert result["status"] == "blocked"
+    assert "Shell control syntax is not allowed" in result["message"]
+
+
+def test_run_guarded_step_blocks_command_path_mismatch() -> None:
+    result = run_guarded_step(
+        step_name="doctor",
+        command_path="doctor",
+        command="entomokit --version",
+        user_inputs={},
+        runner=_ok_runner,
+    )
+
+    assert result["status"] == "blocked"
+    assert "does not match the guarded step" in result["message"]


### PR DESCRIPTION
## Summary
  - harden guarded command validation by tokenizing commands, blocking shell control syntax, and rejecting prefix
  spoofing
  - rebuild `entomokit` execution argv from approved schema-backed parameters, enforce guarded command-path matching,
  and execute with `shell=False`
  - add `action_kind` to exported CLI schema so boolean flags can be reconstructed safely
  - make annotation and metadata outputs explicitly UTF-8 encoded for non-ASCII content
  - add regression coverage for guarded execution and UTF-8 output handling

  ## Testing
  - `pytest tests/test_execution_policy.py tests/test_workflow_gate.py tests/test_run_guarded_step_script.py tests/
  test_cli_schema.py tests/test_annotation_writer.py tests/test_metadata.py tests/test_synthesis_annotation_formats.py`
  - Result: `24 passed, 9 skipped`