### PR TITLE
fix(split-csv): ensure class count CSVs always have label and count columns (v0.1.7)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="entomokit",
-    version="0.1.6",
+    version="0.1.7",
     description="A Python toolkit for building insect image datasets with segmentation, frame extraction, cleaning, dataset splitting, and image synthesis capabilities",
     author="Feng ZHANG",
     author_email="xtmtd.zf@gmail.com",

--- a/src/splitting/splitter.py
+++ b/src/splitting/splitter.py
@@ -24,6 +24,13 @@ class DatasetSplitter:
         self.class_counts: Optional[pd.DataFrame] = None
         self.total_samples = 0
 
+    def _write_class_count(self, data: pd.DataFrame, filename: str) -> None:
+        """Write class count CSV with explicit label/count columns."""
+        counts = (
+            data["label"].value_counts().rename_axis("label").reset_index(name="count")
+        )
+        counts.to_csv(self.class_count_dir / filename, index=False)
+
     def load_data(self) -> None:
         """Load and validate input CSV."""
         if not os.path.exists(self.raw_image_csv):
@@ -36,7 +43,7 @@ class DatasetSplitter:
         class_counts.columns = ["label", "count"]
         self.class_counts = class_counts
 
-        class_counts.to_csv(self.class_count_dir / "class.count", index=False)
+        self._write_class_count(self.all_data, "class.count")
 
         print(f"Loaded {self.total_samples} samples, {len(class_counts)} classes.")
 
@@ -75,9 +82,7 @@ class DatasetSplitter:
             ].reset_index(drop=True)
 
             test_unknown_data.to_csv(self.out_dir / "test.unknown.csv", index=False)
-            test_unknown_data.label.value_counts().to_csv(
-                self.class_count_dir / "class.test.unknown.count", index=False
-            )
+            self._write_class_count(test_unknown_data, "class.test.unknown.count")
         else:
             print("Skip unknown ratio split, ratio=0")
 
@@ -93,12 +98,8 @@ class DatasetSplitter:
             train_data.to_csv(self.out_dir / "train.csv", index=False)
             test_known_data.to_csv(self.out_dir / "test.known.csv", index=False)
 
-            train_data.label.value_counts().to_csv(
-                self.class_count_dir / "class.train.count", index=False
-            )
-            test_known_data.label.value_counts().to_csv(
-                self.class_count_dir / "class.test.known.count", index=False
-            )
+            self._write_class_count(train_data, "class.train.count")
+            self._write_class_count(test_known_data, "class.test.known.count")
         else:
             print("No known data after unknown split.")
 
@@ -112,13 +113,9 @@ class DatasetSplitter:
             val_data = train_data.loc[val_idx].reset_index(drop=True)
             train_data = train_data.drop(val_idx).reset_index(drop=True)
             train_data.to_csv(self.out_dir / "train.csv", index=False)
-            train_data.label.value_counts().to_csv(
-                self.class_count_dir / "class.train.count", index=False
-            )
+            self._write_class_count(train_data, "class.train.count")
             val_data.to_csv(self.out_dir / "val.csv", index=False)
-            val_data.label.value_counts().to_csv(
-                self.class_count_dir / "class.val.count", index=False
-            )
+            self._write_class_count(val_data, "class.val.count")
 
         return {
             "test_unknown": len(test_unknown_data),
@@ -162,9 +159,7 @@ class DatasetSplitter:
             df = df[~df.label.isin(unknown_labels)].reset_index(drop=True)
 
             test_unknown_data.to_csv(self.out_dir / "test.unknown.csv", index=False)
-            test_unknown_data.label.value_counts().to_csv(
-                self.class_count_dir / "class.test.unknown.count", index=False
-            )
+            self._write_class_count(test_unknown_data, "class.test.unknown.count")
 
         if known_test_sample_count > 0:
             target_known = known_test_sample_count
@@ -191,9 +186,7 @@ class DatasetSplitter:
 
         if len(test_known_data) > 0:
             test_known_data.to_csv(self.out_dir / "test.known.csv", index=False)
-            test_known_data.label.value_counts().to_csv(
-                self.class_count_dir / "class.test.known.count", index=False
-            )
+            self._write_class_count(test_known_data, "class.test.known.count")
 
         train_rows = []
         for lbl, group in remain_df.groupby("label"):
@@ -210,9 +203,7 @@ class DatasetSplitter:
         if len(train_rows) > 0:
             train_data = pd.concat(train_rows).reset_index(drop=True)
             train_data.to_csv(self.out_dir / "train.csv", index=False)
-            train_data.label.value_counts().to_csv(
-                self.class_count_dir / "class.train.count", index=False
-            )
+            self._write_class_count(train_data, "class.train.count")
 
         val_data = pd.DataFrame()
         if val_count > 0 and len(train_data) > 0:
@@ -235,13 +226,9 @@ class DatasetSplitter:
                     drop=True
                 )
                 train_data.to_csv(self.out_dir / "train.csv", index=False)
-                train_data.label.value_counts().to_csv(
-                    self.class_count_dir / "class.train.count", index=False
-                )
+                self._write_class_count(train_data, "class.train.count")
                 val_data.to_csv(self.out_dir / "val.csv", index=False)
-                val_data.label.value_counts().to_csv(
-                    self.class_count_dir / "class.val.count", index=False
-                )
+                self._write_class_count(val_data, "class.val.count")
 
         return {
             "test_unknown": len(test_unknown_data),

--- a/tests/test_split_csv.py
+++ b/tests/test_split_csv.py
@@ -151,3 +151,15 @@ def test_split_csv_parser_uses_sample_based_argument_names() -> None:
     assert args.known_test_sample_ratio == 0.1
     assert args.unknown_test_sample_count == 5
     assert args.known_test_sample_count == 10
+
+
+def test_class_count_outputs_keep_label_and_count_columns(tmp_path, sample_csv):
+    csv_path, _ = sample_csv
+    out_dir = tmp_path / "out"
+    splitter = DatasetSplitter(str(csv_path), str(out_dir), seed=42)
+
+    splitter.split(mode="ratio", known_test_ratio=0.1, val_ratio=0.1)
+
+    for name in ["class.train.count", "class.test.known.count", "class.val.count"]:
+        count_df = pd.read_csv(out_dir / "class_count" / name)
+        assert list(count_df.columns) == ["label", "count"]


### PR DESCRIPTION
## Summary
- **Bug fix**: `split-csv` was producing single-column `class.*.count` files because `value_counts().to_csv(index=False)` silently dropped the `label` column from the index. Only `class.count` was correct (it used `reset_index` first).
- **Fix**: Added `_write_class_count()` helper that consistently produces `label,count` CSV columns across all split modes and all output files.
- **Regression test**: Added `test_class_count_outputs_keep_label_and_count_columns` to prevent recurrence.
- **Version bump**: 0.1.6 → 0.1.7

## Test Plan
- [x] `pytest tests/test_split_csv.py` — 7/7 pass
- [x] Manual verification with `entomokit split-csv --raw-image-csv ... --known-test-sample-ratio 0.1`